### PR TITLE
Properly check for raid level 0

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks.alex@trull.org'
 license          'Apache 2.0'
 description      'Creates Dynamic Ephemeral Raids on EC2'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.0.7'
+version          '0.0.8'
 
 %w{ ubuntu debian redhat fedora centos scientific amazon }.each do |os|
   supports os

--- a/recipes/makeraid.rb
+++ b/recipes/makeraid.rb
@@ -21,7 +21,7 @@
 #
 # This recipe based directly on that by Mike Heffner of Librato:
 # https://github.com/librato/basenode-chef-kitchen/blob/master/cookbooks/ephemeral/recipes/raid_ephemeral.rb
-# 
+#
 # Which was in turn modeled after the following :
 # https://github.com/riptano/CassandraClusterAMI/blob/master/.startcassandra.py
 #
@@ -31,7 +31,7 @@
 ephemeral_devices = EphemeralDevices::Helper.get_ephemeral_devices(node.cloud.provider, node)
 
 
-if ( node[:ephemeral][:raid][:level] == "0" )
+if ( node[:ephemeral][:raid][:level].to_s == "0" )
   # We call the mdadm resource provider without a bitmap or spares entry.
   mdadm "#{node[:ephemeral][:raid][:device]}" do
     devices ephemeral_devices
@@ -62,4 +62,3 @@ execute "set_readahead_on_device_after_creation" do
   only_if "which blockdev"
   only_if "test -b #{node[:ephemeral][:raid][:device]}"
 end
-


### PR DESCRIPTION
The default attributes for the raid level is the integer 0. The check
for the raid level is looking for the string "0". This causes a bug
where a configuration with raid level 0 will go to the else case and
fail because bitmap is passed as an argument to the mdadm command.
