### PR TITLE
Fix bug for one ephemeral device case

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -35,7 +35,7 @@ else
 
     log "Ephemeral devices not found"
 
-  elsif ( ephemeral_devices.length >= 2 ) || ( ephemeral_devices.length == 1 && node[:ephemeral][:raid][:force] = true )
+  elsif ( ephemeral_devices.length >= 2 ) || ( ephemeral_devices.length == 1 && node[:ephemeral][:raid][:force] == true )
 
     # We have more than one, or we have one and we are forcing it.
 


### PR DESCRIPTION
Running ephemeral_raid cookbook on a node with just one ephemeral device causes the following error:

[2015-05-14T07:26:12+02:00] ERROR: Node attributes are read-only when you do not specify which precedence level to set. To set an attribute use code like `node.default["
key"] = "value"'

Clearly the assignment should be a comparison. This pull request fixes that issue.
