### PR TITLE
Fix raid creation error occuring when AMI's device mapping contains more devices than actually available for the given instance type.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ bin/*
 
 .kitchen/
 .kitchen.local.yml
+.chef

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of ephemeral_raid.
 
+## 0.0.10:
+* Fix raid creation error occuring when AMI's device mapping contains more devices than actually available for the given instance type.
+See https://github.com/atrull/ephemeral_raid_cookbook/issues/3 for details
+
 ## 0.0.9:
 * Fix to single device handling thanks to Klaas Jan Wierenga (kjwierenga)
 

--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -100,6 +100,7 @@ module EphemeralDevices
             fixed_device
           else
             Chef::Log.warn "could not find ephemeral device: #{device}"
+            nil
           end
         end
       end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks.alex@trull.org'
 license          'Apache 2.0'
 description      'Creates Dynamic Ephemeral Raids on EC2 or GCE'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.0.10'
+version          '0.0.11'
 
 %w{ ubuntu debian redhat fedora centos scientific amazon }.each do |os|
   supports os

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks.alex@trull.org'
 license          'Apache 2.0'
 description      'Creates Dynamic Ephemeral Raids on EC2'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.0.9'
+version          '0.0.10'
 
 %w{ ubuntu debian redhat fedora centos scientific amazon }.each do |os|
   supports os


### PR DESCRIPTION
This branch fixes raid creation error occuring when AMI's device mapping contains more devices than actually available for the given instance type.
See https://github.com/atrull/ephemeral_raid_cookbook/issues/3 for details.